### PR TITLE
13751 - [WEB] Adicionar a barra de busca com botão de filtro na tela de listagem de leilões ativos. / 13754 - [WEB] Criar interface (TAGs) para exibição dos filtros ativos. / 13756 - [WEB] Adicionar botões de exclusão individuais nas TAGs.

### DIFF
--- a/components/auctions/AuctionList.vue
+++ b/components/auctions/AuctionList.vue
@@ -2,23 +2,36 @@
   <div>
     <AuctionSearch v-model:search-query="searchQuery" />
 
-    <div class="d-flex flex-wrap ga-4">
-      <div v-for="auction in filteredAuctions" :key="auction.title">
-        <AuctionCard
-          :title="auction.title"
-          :type="auction.type"
-          :remaining-time="auction.remainingTime"
-          :highest-bid="auction.highestBid"
-        />
+    <div
+      v-if="filteredAuctions.length === 0"
+      class="d-flex justify-center mt-16"
+    >
+      <div class="no-results-card d-flex flex-column align-center justify-center pa-6 mt-8" max-width="400">
+        <v-icon size="125" color="secondary">mdi-magnify</v-icon>
+        <div class="mt-4 font-subtitle font-weight-semibold text-secondary text-center">Nenhum leilão encontrado</div>
       </div>
     </div>
-    <div class="d-flex justify-center ga-2 mt-16">
-      <v-btn class="btn btn-secondary font-small" height="32" width="85"
-        >Anterior</v-btn
-      >
-      <v-btn class="btn btn-primary font-small" height="32" width="85"
-        >Próxima</v-btn
-      >
+
+    <div v-else>
+      <div class="d-flex flex-wrap ga-4">
+        <div v-for="auction in filteredAuctions" :key="auction.title">
+          <AuctionCard
+            :title="auction.title"
+            :type="auction.type"
+            :remaining-time="auction.remainingTime"
+            :highest-bid="auction.highestBid"
+          />
+        </div>
+      </div>
+
+      <div class="d-flex justify-center ga-2 mt-16">
+        <v-btn class="btn btn-secondary font-small" height="32" width="85">
+          Anterior
+        </v-btn>
+        <v-btn class="btn btn-primary font-small" height="32" width="85">
+          Próxima
+        </v-btn>
+      </div>
     </div>
   </div>
 </template>
@@ -62,3 +75,10 @@ const filteredAuctions = computed(() => {
   );
 });
 </script>
+
+<style scoped>
+.no-results-card {
+  background-color: rgba(var(--v-theme-font-10), 0.7);
+  border-radius: 6px;
+}
+</style>

--- a/components/auctions/AuctionList.vue
+++ b/components/auctions/AuctionList.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
+    <AuctionSearch v-model:search-query="searchQuery" />
+
     <div class="d-flex flex-wrap ga-4">
-      <div v-for="auction in auctions" :key="auction.title">
+      <div v-for="auction in filteredAuctions" :key="auction.title">
         <AuctionCard
           :title="auction.title"
           :type="auction.type"
@@ -23,6 +25,7 @@
 
 <script setup lang="ts">
 import AuctionCard from "~/components/auctions/AuctionCard.vue";
+import AuctionSearch from "~/components/auctions/AuctionSearch.vue";
 
 const auctions = [
   {
@@ -50,4 +53,12 @@ const auctions = [
     highestBid: 12000,
   },
 ];
+
+const searchQuery = ref("");
+
+const filteredAuctions = computed(() => {
+  return auctions.filter((auction) =>
+    auction.title.toLowerCase().includes(searchQuery.value.toLowerCase())
+  );
+});
 </script>

--- a/components/auctions/AuctionList.vue
+++ b/components/auctions/AuctionList.vue
@@ -25,10 +25,10 @@
       </div>
 
       <div class="d-flex justify-center ga-2 mt-16">
-        <v-btn class="btn btn-secondary font-small" height="32" width="85">
+        <v-btn id="previous-auctions-page-btn" class="btn btn-secondary font-small" height="32" width="85">
           Anterior
         </v-btn>
-        <v-btn class="btn btn-primary font-small" height="32" width="85">
+        <v-btn id="next-auctions-page-btn" class="btn btn-primary font-small" height="32" width="85">
           Próxima
         </v-btn>
       </div>

--- a/components/auctions/AuctionSearch.vue
+++ b/components/auctions/AuctionSearch.vue
@@ -1,30 +1,49 @@
 <template>
-  <div class="d-flex justify-center mb-4">
-    <v-text-field
-      v-model="searchQuery"
-      placeholder="Pesquisar..."
-      outlined
-      hide-details
-      max-width="500"
-    >
-      <template #prepend-inner>
-        <v-icon size="20" color="primary" class="mb-4 mr-1">mdi-magnify</v-icon>
-      </template>
-
-      <template #append-inner>
-        <v-btn variant="text" :ripple="false" size="20" class="mb-4 pl-1">
+  <div class="d-flex flex-column justify-center ga-4 mb-4">
+    <div class="d-flex justify-center">
+      <v-text-field
+        id="auctions-search-textfield"
+        v-model="searchQuery"
+        placeholder="Pesquisar..."
+        outlined
+        hide-details
+        max-width="500"
+      >
+        <template #prepend-inner>
           <v-icon size="20" color="primary" class="mb-4 mr-1"
-            >mdi-filter-variant</v-icon
+            >mdi-magnify</v-icon
           >
-        </v-btn>
-      </template>
-    </v-text-field>
+        </template>
+
+        <template #append-inner>
+          <v-btn variant="text" :ripple="false" size="20" class="mb-4 pl-1">
+            <v-icon size="20" color="primary" class="mb-4 mr-1"
+              >mdi-filter-variant</v-icon
+            >
+          </v-btn>
+        </template>
+      </v-text-field>
+    </div>
+    <div class="d-flex justify-center ga-2">
+      <div v-for="(filter, index) in appliedFilters" :key="index">
+        <v-chip
+          density="compact"
+          class="d-flex align-center font-small font-weight-semibold"
+        >
+          {{ filter }}
+          <template #close>
+            <v-icon size="12" class="ml-1">mdi-close</v-icon>
+          </template>
+        </v-chip>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-const searchQuery = ref("");
 const emit = defineEmits(["update:searchQuery"]);
+const searchQuery = ref("");
+const appliedFilters = ["Relíquia", "Automóvel"];
 
 watch(searchQuery, (newQuery) => {
   emit("update:searchQuery", newQuery);
@@ -50,5 +69,11 @@ watch(searchQuery, (newQuery) => {
 :deep(.v-field__prepend-inner > .v-icon),
 :deep(.v-field__append-inner > .v-icon) {
   opacity: 1;
+}
+
+:deep(.v-chip) {
+  border-radius: 6px;
+  color: rgba(var(--v-theme-font-10));
+  background-color: rgba(var(--v-theme-secondary));
 }
 </style>

--- a/components/auctions/AuctionSearch.vue
+++ b/components/auctions/AuctionSearch.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="d-flex justify-center mb-4">
+    <v-text-field
+      v-model="searchQuery"
+      placeholder="Pesquisar..."
+      outlined
+      hide-details
+      max-width="500"
+    >
+      <template #prepend-inner>
+        <v-icon size="20" color="primary" class="mb-4 mr-1">mdi-magnify</v-icon>
+      </template>
+
+      <template #append-inner>
+        <v-btn variant="text" :ripple="false" size="20" class="mb-4 pl-1">
+          <v-icon size="20" color="primary" class="mb-4 mr-1"
+            >mdi-filter-variant</v-icon
+          >
+        </v-btn>
+      </template>
+    </v-text-field>
+  </div>
+</template>
+
+<script setup lang="ts">
+const searchQuery = ref("");
+const emit = defineEmits(["update:searchQuery"]);
+
+watch(searchQuery, (newQuery) => {
+  emit("update:searchQuery", newQuery);
+});
+</script>
+
+<style scoped>
+:deep(.v-input__control) {
+  height: 40px;
+}
+
+:deep(.v-field--variant-outlined .v-field__outline) {
+  color: rgba(var(--v-theme-primary)) !important;
+  border-radius: 6px !important;
+  --v-field-border-opacity: 1 !important;
+  --v-field-border-width: 2px !important;
+}
+
+:deep(.v-field__input) {
+  padding-top: 0;
+}
+
+:deep(.v-field__prepend-inner > .v-icon),
+:deep(.v-field__append-inner > .v-icon) {
+  opacity: 1;
+}
+</style>

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -28,6 +28,10 @@ export default defineNuxtPlugin((app) => {
       VBtn: {
         variant: "flat",
       },
+      VTextField: {
+        variant: "outlined",
+        color: "primary",
+      },
     },
   });
   app.vueApp.use(vuetify);

--- a/tests/components/auctions/AuctionList.spec.ts
+++ b/tests/components/auctions/AuctionList.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import AuctionList from "@/components/auctions/AuctionList.vue";
+import AuctionCard from "@/components/auctions/AuctionCard.vue";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let wrapper: any;
@@ -13,12 +14,69 @@ const ResizeObserverMock = vi.fn(() => ({
 
 vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 
+const mockAuctions = [
+  {
+    title: "Pintura de Paisagem do Século XIX",
+    type: "Leilão invertido",
+    remainingTime: 97645,
+    highestBid: 2800000000,
+  },
+  {
+    title: "Escultura de Mármore",
+    type: "Leilão tradicional",
+    remainingTime: 2456,
+    highestBid: 0,
+  },
+  {
+    title: "Relógio de Ouro Antigo",
+    type: "Leilão por proximidade",
+    remainingTime: 34567,
+    highestBid: 500000,
+  },
+  {
+    title: "Carro Clássico",
+    type: "Leilão invertido",
+    remainingTime: 0,
+    highestBid: 12000,
+  },
+];
+
+vi.stubGlobal("auctions", mockAuctions);
+
 describe("AuctionList", () => {
   beforeEach(async () => {
     wrapper = await mountSuspended(AuctionList, {});
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render the AuctionList component", () => {
     expect(wrapper.exists()).toBeTruthy();
+  });
+  it("should display no results when no auctions match the search query", async () => {
+    wrapper.vm.searchQuery.value = "Nonexistent Auction";
+    await wrapper.vm.$nextTick();
+
+    const noResultsCard = wrapper.find(".no-results-card");
+    expect(noResultsCard.exists()).toBeTruthy();
+  });
+
+  it("should display auctions when search query matches", async () => {
+    wrapper.vm.searchQuery.value = "Escultura de Mármore";
+    await wrapper.vm.$nextTick();
+
+    const auctionCards = wrapper.findAllComponents(AuctionCard);
+    expect(auctionCards.length).toBeGreaterThan(0);
+  });
+
+  it("should correctly filter auctions based on search query", async () => {
+    wrapper.vm.searchQuery.value = "Pintura";
+    await wrapper.vm.$nextTick();
+
+    const filteredAuctions = wrapper.vm.filteredAuctions;
+    expect(filteredAuctions.length).toBe(1);
+    expect(filteredAuctions[0].title).toBe("Pintura de Paisagem do Século XIX");
   });
 });

--- a/tests/components/auctions/AuctionSearch.spec.ts
+++ b/tests/components/auctions/AuctionSearch.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import AuctionSearch from "@/components/auctions/AuctionSearch.vue";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: any;
+
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+describe("AuctionSearch", () => {
+  beforeEach(async () => {
+    wrapper = await mountSuspended(AuctionSearch, {});
+  });
+
+  it("should render the AuctionSearch component", () => {
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it("should update the searchQuery model when typing in the search field", async () => {
+    const input = wrapper.find("input#auctions-search-textfield");
+    await input.setValue("Sculpture");
+
+    expect(wrapper.vm.searchQuery.value).toBe("Sculpture");
+  });
+
+  it("should emit 'update:searchQuery' event when the search field is updated", async () => {
+    const input = wrapper.find("input#auctions-search-textfield");
+    await input.setValue("Classic Car");
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("update:searchQuery")).toBeTruthy();
+    expect(wrapper.emitted("update:searchQuery")![0]).toEqual(["Classic Car"]);
+  });
+
+  it("should render the applied filters correctly", () => {
+    const chips = wrapper.findAll(".v-chip");
+
+    expect(chips.length).toBe(2);
+    expect(chips[0].text()).toContain("Relíquia");
+    expect(chips[1].text()).toContain("Automóvel");
+  });
+
+  it("should display the search icon and filter button", () => {
+    const searchIcon = wrapper.find("i.mdi-magnify");
+    const filterButton = wrapper.find("i.mdi-filter-variant");
+
+    expect(searchIcon.exists()).toBeTruthy();
+    expect(filterButton.exists()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Alterações

- A barra de pesquisa para pesquisar pelos leilões disponíveis foi criada.
- A interface dos chips que representam os filtros aplicados foram criados.
- Uma mensagem para quando não houverem leilões disponíveis foi implementada

## Como testar?

- Abrir a aplicação no navegador na página de [leilões disponíveis](http://localhost:3000/auctions)
- Verificar o funcionamento da barra de pesquisa e dos chips

## Preview

![image](https://github.com/user-attachments/assets/42f67c3d-34e7-43f9-9f93-a159e90fd24d)